### PR TITLE
docs: fix broken link in  packages/Far/README.md

### DIFF
--- a/packages/far/README.md
+++ b/packages/far/README.md
@@ -1,7 +1,7 @@
 # Agoric Far Object helpers
 
 The `@agoric/far` package provides a convenient way to use the Agoric
-[distributed objects system](https://agoric.com/documentation/js-programming/far.html) without  relying on the underlying messaging
+[distributed objects system](https://agoric.com/documentation/guides/js-programming/far.html#far-remotable-and-marshaling) without  relying on the underlying messaging
 implementation.
 
 It exists to reduce the boilerplate in Hardened JavaScript vats that are running


### PR DESCRIPTION
## Description
Updated README of the Far package to  point to the correct documentation on Far's role in distributed JS

### Security Considerations
N/A 

### Documentation Considerations
Nothing outside of verifying that the new link points to the desired url. 

### Testing Considerations
N/A